### PR TITLE
Fixed empty title in blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+title:       Уютная тумбочка
 name:        bouncepaw
 url:         https://bouncepaw.github.io
 description: Мой сайт / Mia retejo / My site

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,10 +3,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-    {% if page.title == "/" %}
-      {{ site.title }}
-    {% else %}
+    {% if page.layout == "ru" %}
       {{ page.title }} &middot; {{ site.title }}
+    {% else %}
+      {{ site.title }}
     {% endif %}
   </title>
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: Уютная тумбочка
 ---
 <section class="hero">
   <img alt="" src="data/img/cozy-bedside.png" class="hero__logo"/>


### PR DESCRIPTION
The main problem was the missing `title` property in `_config.yml`, which I fixed in this pull request. Also I removed explicit `title` front-matter property from `index.html` and rewrote title logic in `_includes/head.html` accordingly.